### PR TITLE
Add Easy Git as a SCM implementation

### DIFF
--- a/gmp/scm.py
+++ b/gmp/scm.py
@@ -12,6 +12,9 @@ class SCM:
     """The scm binary, e.g. "git" """
     binary = None
 
+    """The default metadata directory is .git"""
+    metadata_dir = ".git"
+
     """Aliases for scm command. e.g if defined clone: svn clone, every
     clone command will be replaced by svn clone"""
     aliases = {}
@@ -120,7 +123,7 @@ class SCM:
         """'+' if the repository exists
            'N' if the destination directory exists but isn't a git repo
            '-' if the destination doesn't exists"""
-        if os.path.exists(os.path.join(local_url, "." + self.binary)):
+        if os.path.exists(os.path.join(local_url, self.metadata_dir)):
             return self.STATE_EXISTS
         elif os.path.exists(os.path.join(local_url, "refs")):
             return self.STATE_BARE
@@ -147,6 +150,16 @@ class Git(SCM):
         SCM.__init__(self)
 
 git = Git()
+
+
+class Eg(SCM):
+    name = "easygit"
+    binary = "eg"
+    def __init__(self):
+        SCM.__init__(self)
+
+eg = Eg()
+
 
 class GitSvn(Git):
     """This Repository type replaces push/clone/pull with the git svn 
@@ -220,6 +233,7 @@ git_svn_externals = gitsvn_externals = GitSvn(externals = True)
 class Mercurial(SCM):
     name = "hg"
     binary = "hg"
+    metadata_dir = ".hg"
     def __init__(self):
         SCM.__init__(self)
 mercurial = hg = Mercurial()


### PR DESCRIPTION
Hi,

I am using Easy Git as a wrapper around git and would like to use that in metagit too. So I added it :-)
Hmm...might "look" better to extend Eg from Git instead of SCM maybe...

Regards,
Stig Kleppe-Jørgensen
