### PR TITLE
Added gitolite lister and Easy Git SCM implementations

### DIFF
--- a/gmp/listers.py
+++ b/gmp/listers.py
@@ -38,7 +38,7 @@ class RepoLister (PolicyMixin):
 
     def urls(self):
         """Retures a list of clone urls in the SSHDir"""
-        if self.clone_urls == None:
+        if self.clone_urls is None:
             self.get_list()
         return self.clone_urls
 

--- a/gmp/listers.py
+++ b/gmp/listers.py
@@ -139,6 +139,41 @@ directory: remote directory where the git repos are searched"""
 
         return Repository(push_url, local, default_policy = self.default_policy, scm = self.scm)
         
+
+class Gitolite(RepoLister):
+    """With this you can work against a Gitolite server on a remote host"""
+
+    def __init__(self, host, **kwargs):
+        """host: server where gitolite is running"""
+        if not 'scm' in kwargs:
+            kwargs['scm'] = Git()
+        RepoLister.__init__(self, **kwargs)
+        self.host = host
+
+    def get_list(self):
+        process = subprocess.Popen(["ssh", self.host, "expand"],
+                                   stdout = subprocess.PIPE)
+
+        self.clone_urls = []
+        for repo in process.stdout.readlines():
+            repo = repo.strip()
+            #     &R_ &W_	<gitolite>	nosmd
+            m = re.match("^.*\t(.*)$", repo)
+
+            if m:
+                self.clone_urls.append((self.host + ":" + m.group(1) + ".git", m.group(1)))
+
+    def can_upload(self):
+        """You can push a local repository to a gitolite server"""
+        return True
+
+    def upload(self, local, remote):
+        """Pushes a local repository to a gitolite server"""
+
+        print "TODO: Need to setup initial config for pushing to gitolite and then push"
+        sys.exit(-1)
+
+
 class Github(RepoLister):
     def __init__(self, username = None, protocol="ssh", wiki = False, **kwargs):
         """Uses a github account name to get a list of repositories

--- a/gmp/scm.py
+++ b/gmp/scm.py
@@ -144,8 +144,8 @@ class SCM:
         return self.bare_execute("clone", [remote_repo, local_repo])
         
 class Git(SCM):
-    binary = "git"
     name = "git"
+    binary = "git"
     def __init__(self):
         SCM.__init__(self)
 

--- a/gmp/scm.py
+++ b/gmp/scm.py
@@ -12,6 +12,9 @@ class SCM:
     """The scm binary, e.g. "git" """
     binary = None
 
+    """The default metadata directory is .git"""
+    metadata_dir = ".git"
+
     """Aliases for scm command. e.g if defined clone: svn clone, every
     clone command will be replaced by svn clone"""
     aliases = {}
@@ -120,7 +123,7 @@ class SCM:
         """'+' if the repository exists
            'N' if the destination directory exists but isn't a git repo
            '-' if the destination doesn't exists"""
-        if os.path.exists(os.path.join(local_url, "." + self.binary)):
+        if os.path.exists(os.path.join(local_url, self.metadata_dir)):
             return self.STATE_EXISTS
         elif os.path.exists(os.path.join(local_url, "refs")):
             return self.STATE_BARE
@@ -147,6 +150,16 @@ class Git(SCM):
         SCM.__init__(self)
 
 git = Git()
+
+
+class Eg(SCM):
+    name = "easygit"
+    binary = "eg"
+    def __init__(self):
+        SCM.__init__(self)
+
+eg = Eg()
+
 
 class GitSvn(Git):
     """This Repository type replaces push/clone/pull with the git svn 
@@ -220,6 +233,7 @@ git_svn_externals = gitsvn_externals = GitSvn(externals = True)
 class Mercurial(SCM):
     name = "hg"
     binary = "hg"
+    metadata_dir = ".hg"
     def __init__(self):
         SCM.__init__(self)
 mercurial = hg = Mercurial()

--- a/gmp/scm.py
+++ b/gmp/scm.py
@@ -138,10 +138,10 @@ class SCM:
     # subclassing. These functions will overide the normal execution function
     #
     def clone(self, args = [], destdir = None):
-        [remote_repo, local_repo] = args
         """Calling this method will clone the remote_repo
         to the local url. This method will execute the command"""
-        return self.bare_execute("clone", [remote_repo, local_repo])        
+        [remote_repo, local_repo] = args
+        return self.bare_execute("clone", [remote_repo, local_repo])
         
 class Git(SCM):
     binary = "git"

--- a/gmp/scm.py
+++ b/gmp/scm.py
@@ -152,11 +152,12 @@ class Git(SCM):
 git = Git()
 
 
-class Eg(SCM):
+class Eg(Git):
+    """This is for the Easy Git wrapper"""
     name = "easygit"
     binary = "eg"
     def __init__(self):
-        SCM.__init__(self)
+        Git.__init__(self)
 
 eg = Eg()
 


### PR DESCRIPTION
Hi again,

I had some more changes coming in, so you can just delete the previous request.

I've added a gitolite lister which works against a remote gitolite server. By running ssh against it with the expand command, it will return a list of all repositories. The expand command makes gitolite also list everything "behind" wildcard repositores if this is enabled on the server.

As explained in the previous request, this also includes an Easy Git SCM implementation, which is a nice git wrapper.

The other commits are just more or less code style, and as I am newbie in Python these might be way off :-)

Regards,
Stig
